### PR TITLE
(#28) - Rename "engineering" to "guides"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - npm install -g gulp
   - npm install
 before_script:
-  - git remote set-url origin "https://${GH_TOKEN}@github.com/atsid/engineering.git"
+  - git remote set-url origin "https://${GH_TOKEN}@github.com/atsid/guides.git"
   - git config --global user.email "github@atsid.com"
   - git config --global user.name "Travis-CI"
 script:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![Dependency Status](https://david-dm.org/atsid/engineering.svg)](https://david-dm.org/atsid/engineering)
-[![Dev Dependency Status](https://david-dm.org/atsid/engineering/dev-status.svg)](https://david-dm.org/atsid/engineering)
-[![Build Status](https://travis-ci.org/atsid/engineering.svg?branch=master)](https://travis-ci.org/atsid/engineering)
+[![Dependency Status](https://david-dm.org/atsid/guides.svg)](https://david-dm.org/atsid/guides)
+[![Dev Dependency Status](https://david-dm.org/atsid/guides/dev-status.svg)](https://david-dm.org/atsid/guides)
+[![Build Status](https://travis-ci.org/atsid/guides.svg?branch=master)](https://travis-ci.org/atsid/guides)
 
-# engineering
+# guides
 
 Docs and discussion about ATS software delivery culture and practices.
 
@@ -19,7 +19,7 @@ Once you've made all the edits you'd like, push your branch and submit a pull re
 and discussed by the team, you should get a :shipit: or two indicating that it's ready to go. At that point, merge the branch into `master`,
 and the Travis build will automatically re-deploy the site to gh-pages.
 
-*The workflow of branching, submitting a PR, then merging is covered more thoroughly in our [GitHub guide](https://github.com/atsid/engineering/blob/master/github.md).*
+*The workflow of branching, submitting a PR, then merging is covered more thoroughly in our [GitHub guide](https://github.com/atsid/guides/blob/master/github.md).*
 
 ### Development Guides
 
@@ -50,11 +50,11 @@ We use Vagrant to streamline the installation of Jekyll so you can run the site 
 1. `vagrant ssh`
 1. `cd /vagrant`
 1. Start jekyll: `jekyll serve`
-1. View the site on your host machine: http://localhost:4000/engineering
+1. View the site on your host machine: http://localhost:4000/guides
 
 ### Deployment
 
-Deployment uses a gulp task to push to `gh-pages`, where it can be viewed at http://labs.atsid.com/engineering/.
+Deployment uses a gulp task to push to `gh-pages`, where it can be viewed at http://labs.atsid.com/guides/.
 
 1. Get dev dependencies: `npm install`
 1. Install gulp if you don't have it: `npm install -g gulp`

--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,9 @@
 # Site settings
 title: Software Delivery
-email: engineering@atsid.com
+email: software@atsid.com
 description: > # this means to ignore newlines until "baseurl:"
   ATS software delivery culture and practices
-baseurl: "/engineering" # the subpath of your site, e.g. /blog/
+baseurl: "/guides" # the subpath of your site, e.g. /blog/
 url: "http://labs.atsid.com" # the base hostname & protocol for your site
 github_username:  atsid
 twitter_username:  ats_inc

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
       <div class="footer-col  footer-col-1">
         <ul class="contact-list">
           <li><a href="mailto:{{ site.email }}">{{ site.email }}</a></li>
-          <li><a href="https://github.com/atsid/engineering">Contribute to this site at GitHub!</a></li>
+          <li><a href="https://github.com/atsid/guides">Contribute to this site at GitHub!</a></li>
         </ul>
       </div>
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "engineering",
+  "name": "guides",
   "version": "0.0.2",
   "private": false,
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/atsid/engineering.git"
+    "url": "https://github.com/atsid/guides.git"
   },
   "author": "ATS",
   "dependencies": {},


### PR DESCRIPTION
Replaced "engineering" wherever it occurred with "guides" so all paths and links are correct.