### PR TITLE
54 jekyll upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ We use Vagrant to streamline the installation of Jekyll so you can run the site 
 1. `vagrant up`
 1. `vagrant ssh`
 1. `cd /vagrant`
-1. Start jekyll: `jekyll serve`
+1. Start jekyll: `jekyll serve --host 0.0.0.0` or use the handy bash alias `serve`
 1. View the site on your host machine: http://localhost:4000/guides
 
 ### Deployment
@@ -50,4 +50,3 @@ Deployment uses a gulp task to push to `gh-pages`, where it can be viewed at htt
 1. `gulp deploy`
 
 Note again that this process happens automatically by Travis whenever commits are made to master.
-

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,6 +19,9 @@ Vagrant.configure(2) do |config|
   # Forward server ports from guest to host
   config.vm.network "forwarded_port", guest: 4000, host: 4000
 
+  # Handy jekyll alias to include open host
+  config.vm.provision :shell, inline: 'echo "alias serve=\"jekyll serve --host 0.0.0.0\"" >> .bashrc'
+
   # Shared folders with NFS
   config.vm.network :private_network, type: "dhcp"
   config.vm.synced_folder '.', '/vagrant', nfs: true

--- a/salt/roots/ruby.sls
+++ b/salt/roots/ruby.sls
@@ -5,5 +5,5 @@ ruby:
     - names:
       - zlib1g-dev
       - build-essential
-      - ruby2.1
-      - ruby2.1-dev
+      - ruby2.2
+      - ruby2.2-dev


### PR DESCRIPTION
These changes get the guides site Vagrant config onto the latest version of Ruby and Jekyll used by GitHub Pages. There is also a change to the command used to start Jekyll within Vagrant, because newer versions need to have non-localhost access explicitly allowed.